### PR TITLE
fix gtest issues w/recent OS X compilers

### DIFF
--- a/build-common/cmake/TestHelper.cmake
+++ b/build-common/cmake/TestHelper.cmake
@@ -12,6 +12,7 @@ ExternalProject_Add(
     gtest160
     URL ${CMAKE_CURRENT_SOURCE_DIR}/build-common/vendor/gtest-1.6.0.tar.gz
     INSTALL_COMMAND ""
+    CMAKE_ARGS -DCMAKE_CXX_FLAGS=-DGTEST_USE_OWN_TR1_TUPLE=1
     BINARY_DIR ${GTEST_LIB_DIR}
     )
 ExternalProject_Get_Property(gtest160 source_dir)
@@ -33,7 +34,7 @@ set_property(TARGET gtest_main PROPERTY IMPORTED_LOCATION ${GTEST_MAIN_LIBRARY})
 macro(add_unit_tests test_name)
     set(src_files ${ARGN})
     add_executable(${test_name} ${src_files} ${COMMON_SOURCES})
-    target_link_libraries(${test_name} ${TEST_LIBS} gtest gtest_main)
+    target_link_libraries(${test_name} ${TEST_LIBS} gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
     add_dependencies(${test_name} gtest160)
     if($ENV{BC_UNIT_TEST_VG})
         add_test(
@@ -49,7 +50,7 @@ endmacro(add_unit_tests test_name src_files)
 
 macro(def_test testName)
     add_executable(Test${testName} Test${testName}.cpp ${COMMON_SOURCES})
-    target_link_libraries(Test${testName} ${TEST_LIBS} gtest gtest_main)
+    target_link_libraries(Test${testName} ${TEST_LIBS} gtest gtest_main ${CMAKE_THREAD_LIBS_INIT})
     add_dependencies(Test${testName} gtest160)
     if($ENV{BC_UNIT_TEST_VG})
         add_test(NAME Test${testName} COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:Test${testName}>)


### PR DESCRIPTION
tr1/tuple no longer exists in recent clang/libc++. That's because it's part of the official standard now (no longer a technical report).

Gtest still looks for tr1/tuple, but it has a macro GTEST_USE_OWN_TR1_TUPLE that causes it to use its own bundled implementation. We'll just always do that.
