### PR TITLE
pre-build dependency handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_MODULE_PATH
 include(TestHelper)
 include(VersionHelper)
 include(ProjectHelper)
+include(PreDepends)
+PreDependsInit()
 
 #set(EXE_VERSION_SUFFIX ${FULL_VERSION})
 
@@ -27,9 +29,6 @@ include_directories(${Boost_INCLUDE_DIRS})
 include(BuildSamtools)
 include_directories(${Samtools_INCLUDE_DIRS})
 
-add_custom_target(deps ALL)
-add_dependencies(deps samtools-lib boost-1.55)
-
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS "-Wall -std=c++0x")
 endif ()
@@ -39,18 +38,6 @@ link_libraries(${CMAKE_THREAD_LIBS_INIT})
 
 # make sure to pick up headers from library dirs
 include_directories("src/lib")
-
-# unit tests
-find_package(GTest)
-if(GTEST_FOUND)
-    message("Google Test framework found, building unit tests")
-    enable_testing(true)
-    add_projects(test/lib)
-else()
-    message("Google Test framework not found, no tests will be built")
-    message("GTest is available at http://code.google.com/p/googletest/")
-    message("Ubuntu users can likely sudo apt-get install gtest")
-endif()
 
 # main project
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.3)
 
 project(bam-readcount)
 

--- a/README.textile
+++ b/README.textile
@@ -84,7 +84,7 @@ bc. chr	position	reference_base	depth	libname	{	base:count:avg_mapping_quality:a
 h2. Build Dependencies
 
 * git
-* cmake 2.8+ ("cmake.org":http://cmake.org)
+* cmake 2.8.3+ ("cmake.org":http://cmake.org)
 
 h3. Available Packages for Dependencies
 * For APT-based systems (Debian, Ubuntu), install the following packages:
@@ -96,7 +96,7 @@ bc. sudo apt-get install build-essential git-core cmake zlib1g-dev libncurses-de
 bc. sudo yum groupinstall "Development tools" 
 sudo yum install zlib-devel ncurses-devel cmake patch
 
-Note that for some RPM based systems (like RHEL), you will need to install cmake 2.8 or greater yourself as the packaged version is much older.
+Note that for some RPM based systems (like RHEL) and older versions of Ubuntu, you will need to install cmake 2.8.3 or greater yourself as the packaged version is older.
 
 
 h2. Build Instructions

--- a/README.textile
+++ b/README.textile
@@ -110,7 +110,6 @@ h3. Compile bam-readcount
 * bam-readcount does not support in source builds. Create a new build directory, enter it, and run:
 
 bc.         cmake /path/to/bam-readcount/repo
-        make deps
         make
 
 p. The binary can then be found in the bin/ subdirectory of your build directory.

--- a/build-common/cmake/FindHTSlib.cmake
+++ b/build-common/cmake/FindHTSlib.cmake
@@ -1,0 +1,46 @@
+# - Try to find htslib 
+# Once done, this will define
+#
+#  htslib_FOUND - system has htslib
+#  htslib_INCLUDE_DIRS - the htslib include directories
+#  htslib_LIBRARIES - link these to use htslib
+
+set(HTSLIB_SEARCH_DIRS
+    ${HTSLIB_SEARCH_DIRS}
+    $ENV{HTLSIB_ROOT}
+    /gsc/pkg/bio/htslib
+    /usr
+    /usr/local
+)
+
+set(_htslib_ver_path "htslib-${htslib_FIND_VERSION}")
+include(LibFindMacros)
+
+# Dependencies
+libfind_package(HTSlib ZLIB)
+
+# Include dir
+find_path(HTSlib_INCLUDE_DIR
+    NAMES ${HTSLIB_ADDITIONAL_HEADERS} sam.h
+    PATHS ${HTSLIB_SEARCH_DIRS}
+    PATH_SUFFIXES 
+        include include/htslib htslib/${_htslib_ver_path}/htslib
+    HINTS ENV HTSLIB_ROOT
+)
+
+# Finally the library itself
+find_library(HTSlib_LIBRARY
+    NAMES hts libhts.a hts.a
+    PATHS ${HTSlib_INCLUDE_DIR} ${HTSLIB_SEARCH_DIRS}
+    NO_DEFAULT_PATH
+    PATH_SUFFIXES lib lib64 ${_htslib_ver_path}
+    HINTS ENV HTSLIB_ROOT
+)
+
+# Set the include dir variables and the libraries and let libfind_process do the rest.
+# NOTE: Singular variables for this library, plural for libraries this lib depends on.
+set(HTSlib_PROCESS_INCLUDES HTSlib_INCLUDE_DIR ZLIB_INCLUDE_DIR)
+set(HTSlib_PROCESS_LIBS HTSlib_LIBRARY ZLIB_LIBRARIES)
+libfind_process(HTSlib)
+message(STATUS "   HTSlib include dirs: ${HTSlib_INCLUDE_DIRS}")
+message(STATUS "   HTSlib libraries: ${HTSlib_LIBRARIES}")

--- a/build-common/cmake/PreDepends.cmake
+++ b/build-common/cmake/PreDepends.cmake
@@ -1,0 +1,113 @@
+##############################################################################
+# PreDepends.cmake
+#
+# Macros to cope with the fact that cmake doesn't support the notion
+# of dependencies that must be built before any other target when
+# doing parallel builds.
+#
+# SYNOPSIS:
+#
+# Include this file in your top level CMakeLists.txt and call
+#
+#   PredependsInit()
+#
+# precisely once.
+#
+# Then, use
+
+#   ExternalDependency_Add(<NAME> BUILD_BYPRODUCTS <BYPRODUCTS> ARGS ...)
+# instead of
+#   ExternalProject_Add(<NAME> BUILD_BYPRODUCTS <BYPRODUCTS> ...)
+
+#   xadd_executable(<NAME> ...)
+# instead of
+#   add_executable(<NAME> ...)
+
+#   xadd_library(<NAME> ...)
+# instead of
+#   add_library(<NAME> ...)
+
+
+# This will ensure that the external dependencies get built before
+# any targets added with xadd_{executable,library}.
+
+
+# METHODS:
+# This module sets up a dummy target "__bc_predepends" and provides a
+# macro:
+#
+#   add_predepend(foo)
+#
+# This macro makes the __bc_predepends target depend on foo. It can
+# be used directly, e.g.,
+#
+#   ExternalProject_Add(foo BUILD_BYPRODUCTS path/to/libfoo.a ...)
+#   add_predepend(foo)
+#
+# but the typical usage is to call
+#   ExternalDependency_Add(foo BUILD_BYPRODUCTS path/to/libfoo.a ARGS ...)
+# instead.
+#
+# We provide another set of macros:
+#
+#   xadd_executable(bar bar.c)
+#   xadd_library(baz baz.c)
+#
+# These function exactly like the native add_executable/add_library
+# commands, but they also add a dependency on __bc_predepends
+# to the target being generated (bar and baz in this case).
+# This forces any registered predepends targets to be built first.
+# In the example at hand, we get the following dependency graph:
+#
+# bar -----------> __bc_predepends -> foo
+# libbaz.a ----`
+#
+# where a -> b is pronounced "a depends on b".
+#
+# NOTE: cmake 3.2+ is required to use the Ninja generator
+cmake_minimum_required(VERSION 2.8)
+
+set(PREDEPENDS_TARGET_NAME "__bc_predepends")
+
+# Deal with multiple inclusion of this file
+macro(PreDependsInit)
+    add_custom_target(${PREDEPENDS_TARGET_NAME} ALL)
+endmacro()
+
+macro(add_predepend __TARGET_NAME)
+    add_dependencies(${PREDEPENDS_TARGET_NAME} ${__TARGET_NAME})
+endmacro()
+
+macro(xadd_executable __TARGET_NAME)
+    add_executable(${__TARGET_NAME} ${ARGN})
+    add_dependencies(${__TARGET_NAME} ${PREDEPENDS_TARGET_NAME})
+endmacro()
+
+macro(xadd_library __TARGET_NAME)
+    add_library(${__TARGET_NAME} ${ARGN})
+    add_dependencies(${__TARGET_NAME} ${PREDEPENDS_TARGET_NAME})
+endmacro()
+
+macro(ExternalDependency_Add NAME)
+    set(multiValueArgs BUILD_BYPRODUCTS ARGS)
+    cmake_parse_arguments(extdep_add "" "" "${multiValueArgs}" ${ARGN})
+
+    # Listing the byproducts is not needed for the "Unix Makefiles" generator.
+    # It is, however, required for Ninja. I don't know about any of the other
+    # generators...
+    unset(BYPRODUCTS_LIST)
+    if (CMAKE_GENERATOR MATCHES "Ninja")
+        if(CMAKE_VERSION VERSION_LESS "3.2")
+            message(FATAL_ERROR "The Ninja generator requires CMake 3.2+. Try the \"Unix Makefiles\" generator instead.")
+        endif()
+        set(BYPRODUCTS_LIST BUILD_BYPRODUCTS "${extdep_add_BUILD_BYPRODUCTS}")
+    endif()
+
+    set(arg_list "${extdep_add_ARGS}")
+    ExternalProject_Add(
+        ${NAME}
+        "${BYPRODUCTS_LIST}"
+        "${arg_list}"
+    )
+    add_predepend(${NAME})
+endmacro()

--- a/cmake/BuildBoost.cmake
+++ b/cmake/BuildBoost.cmake
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-include(ExternalProject)
-
 set(DEFAULT_BOOST_URL ${CMAKE_SOURCE_DIR}/vendor/boost-1.55-bamrc.tar.gz)
 if(NOT DEFINED BOOST_URL)
     set(BOOST_URL ${DEFAULT_BOOST_URL})
@@ -24,17 +22,19 @@ endforeach(libname ${REQUIRED_BOOST_LIBS})
 message("Extracting boost from ${BOOST_URL}")
 message("Boost build log can be found at ${BOOST_LOG}")
 
-ExternalProject_Add(
+ExternalDependency_Add(
     boost-1.55
-    URL ${BOOST_URL}
-    SOURCE_DIR ${BOOST_SRC}
-    BINARY_DIR ${BOOST_SRC}
-    CONFIGURE_COMMAND "./bootstrap.sh"
-    BUILD_COMMAND
-        echo "Building boost, build log is ${BOOST_LOG}" &&
-        ./b2 --prefix=${BOOST_ROOT} --layout=system link=static
-                threading=multi install ${BOOST_BUILD_LIBS} > ${BOOST_LOG} 2>&1
-    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS ${Boost_LIBRARIES}
+    ARGS
+        URL ${BOOST_URL}
+        SOURCE_DIR ${BOOST_SRC}
+        BINARY_DIR ${BOOST_SRC}
+        CONFIGURE_COMMAND "./bootstrap.sh"
+        BUILD_COMMAND
+            echo "Building boost, build log is ${BOOST_LOG}" &&
+            ./b2 --prefix=${BOOST_ROOT} --layout=system link=static
+                    threading=multi install ${BOOST_BUILD_LIBS} > ${BOOST_LOG} 2>&1
+        INSTALL_COMMAND "true"
 )
 
 set(Boost_INCLUDE_DIRS ${BOOST_ROOT}/include)

--- a/cmake/BuildSamtools.cmake
+++ b/cmake/BuildSamtools.cmake
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-include(ExternalProject)
-
 set(SAMTOOLS_ROOT ${CMAKE_BINARY_DIR}/vendor/samtools)
 set(SAMTOOLS_LOG ${SAMTOOLS_ROOT}/build.log)
 set(SAMTOOLS_LIB ${SAMTOOLS_ROOT}/${CMAKE_FIND_LIBRARY_PREFIXES}bam${CMAKE_STATIC_LIBRARY_SUFFIX})
@@ -11,37 +9,36 @@ find_package(ZLIB)
 if (NOT ZLIB_FOUND)
     set(ZLIB_ROOT ${CMAKE_BINARY_DIR}/vendor/zlib)
     set(ZLIB_SRC ${CMAKE_BINARY_DIR}/vendor/zlib-src)
-    ExternalProject_Add(
-        zlib
-        URL ${CMAKE_SOURCE_DIR}/vendor/zlib-1.2.8.tar.gz
-        SOURCE_DIR ${ZLIB_SRC}
-        BINARY_DIR ${ZLIB_SRC}
-        CONFIGURE_COMMAND ./configure --prefix=${ZLIB_ROOT}
-        BUILD_COMMAND make
-        INSTALL_COMMAND make install
-    )
     set(ZLIB_INCLUDE_DIRS ${ZLIB_ROOT}/include)
     set(ZLIB_LIBRARIES ${ZLIB_ROOT}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}z${CMAKE_STATIC_LIBRARY_SUFFIX})
-    add_library(z STATIC IMPORTED)
-    set_property(TARGET z PROPERTY IMPORTED_LOCATION ${ZLIB_LIBRARIES})
+    ExternalDependency_Add(
+        zlib
+        BUILD_BYPRODUCTS ${ZLIB_LIBRARIES}
+        ARGS
+            URL ${CMAKE_SOURCE_DIR}/vendor/zlib-1.2.8.tar.gz
+            SOURCE_DIR ${ZLIB_SRC}
+            BINARY_DIR ${ZLIB_SRC}
+            CONFIGURE_COMMAND ./configure --prefix=${ZLIB_ROOT}
+            BUILD_COMMAND make
+            INSTALL_COMMAND make install
+    )
 endif (NOT ZLIB_FOUND)
 
-ExternalProject_Add(
+ExternalDependency_Add(
     samtools-lib
-    URL ${CMAKE_SOURCE_DIR}/vendor/samtools-0.1.19.tar.gz
-    SOURCE_DIR ${SAMTOOLS_ROOT}
-    BINARY_DIR ${SAMTOOLS_ROOT}
-    PATCH_COMMAND patch -p2 -t -N < ${CMAKE_SOURCE_DIR}/vendor/samtools0.1.19.patch
-    CONFIGURE_COMMAND echo "Building samtools, build log at ${SAMTOOLS_LOG}"
-    BUILD_COMMAND make INCLUDES=-I${ZLIB_INCLUDE_DIRS} libbam.a > ${SAMTOOLS_LOG} 2>&1
-    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS ${SAMTOOLS_LIB} ${SAMTOOLS_BIN}
+    ARGS
+        URL ${CMAKE_SOURCE_DIR}/vendor/samtools-0.1.19.tar.gz
+        SOURCE_DIR ${SAMTOOLS_ROOT}
+        BINARY_DIR ${SAMTOOLS_ROOT}
+        PATCH_COMMAND patch -p2 -t -N < ${CMAKE_SOURCE_DIR}/vendor/samtools0.1.19.patch
+        CONFIGURE_COMMAND echo "Building samtools, build log at ${SAMTOOLS_LOG}"
+        BUILD_COMMAND make INCLUDES=-I${ZLIB_INCLUDE_DIRS} libbam.a > ${SAMTOOLS_LOG} 2>&1
+        INSTALL_COMMAND "true"
 )
 
-add_library(bam STATIC IMPORTED)
-set_property(TARGET bam PROPERTY IMPORTED_LOCATION ${SAMTOOLS_LIB})
-
 set(Samtools_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS};${SAMTOOLS_ROOT})
-set(Samtools_LIBRARIES bam m ${ZLIB_LIBRARIES})
+set(Samtools_LIBRARIES ${SAMTOOLS_LIB} m ${ZLIB_LIBRARIES})
 
 if (NOT ZLIB_FOUND)
     add_dependencies(samtools-lib zlib)

--- a/src/exe/bam-readcount/CMakeLists.txt
+++ b/src/exe/bam-readcount/CMakeLists.txt
@@ -5,7 +5,7 @@ project(bam-readcount)
 set(SOURCES bamreadcount.cpp)
 
 set(EXECUTABLE_NAME bam-readcount)
-add_executable(${EXECUTABLE_NAME} ${SOURCES})
+xadd_executable(${EXECUTABLE_NAME} ${SOURCES})
 target_link_libraries(${EXECUTABLE_NAME} bamrc ${Samtools_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES PACKAGE_OUTPUT_NAME ${EXECUTABLE_NAME}${EXE_VERSION_SUFFIX})
 install(TARGETS ${EXECUTABLE_NAME} DESTINATION bin/)

--- a/src/lib/bamrc/CMakeLists.txt
+++ b/src/lib/bamrc/CMakeLists.txt
@@ -9,5 +9,5 @@ set(SOURCES
     BasicStat.cpp
 )
 
-add_library(bamrc ${SOURCES})
+xadd_library(bamrc ${SOURCES})
 target_link_libraries(bamrc ${Boost_LIBRARIES} ${Samtools_LIBRARIES} ${ZLIB_LIBRARIES})


### PR DESCRIPTION
hiyo ernfrid.

You asked if I had an example of the predepends cmake hackery I was scheming about some time ago. Here it is. The basic idea is outlined in build-common/cmake/PreDepends.cmake. This gets rid of the deps target and makes parallel builds just work (fixing issue #22).

The catch is: it really wants CMake v3.2. Specifically, the Ninja generator will succeed at generating the project but fail to compile it on anything less. The makefile generator works on 2.8.12+ for me. I added conditional logic to fail with a message like "use make instead" at configure time if you're using ninja on an old cmake.

Don't merge or reject this right away. This is me providing the example you asked about. I'll be back to refine it later on :)