### PR TITLE
Version and Author contri patch

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,58 @@
+{
+  "creators": [
+    {
+      "name": "Ajay Khanna^[co-first author]",
+      "affiliation": "Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "David E. Larson^[co-first author]",
+      "affiliation": "1. McDonnell Genome Institute, Washington University School of Medicine, St. Louis, MO, 2. Current Affiliation: Benson Hill, Inc. St. Louis, MO"
+    },
+    {
+      "name": "Sridhar Nonavinkere Srivatsan",
+      "affiliation": "Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Matthew Mosior",
+      "affiliation": "1. Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO, 2. Moffitt Cancer Center, Tampa, FL"
+    },
+    {
+      "name": "Travis E. Abbott",
+      "affiliation": "1. McDonnell Genome Institute, Washington University School of Medicine, St. Louis, MO, 2. Google, Inc. Mountain View, CA"
+    },
+    {
+      "name": "Susanna Kiwala",
+      "affiliation": "McDonnell Genome Institute, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Timothy J. Ley",
+      "affiliation": "1. Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO, 2. Siteman Cancer Center, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Eric J. Duncavage",
+      "affiliation": "Department of Pathology, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Matthew J. Walter",
+      "affiliation": "1. Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO, 2. Siteman Cancer Center, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Jason R. Walker",
+      "affiliation": "McDonnell Genome Institute, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Obi L. Griffith",
+      "affiliation": "1. Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO, 2.McDonnell Genome Institute, Washington University School of Medicine, St. Louis, MO, 3. Siteman Cancer Center, Washington University School of Medicine, St. Louis, MO, 4.Department of Genetics, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Malachi Griffith",
+      "affiliation": "1. Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO, 2.McDonnell Genome Institute, Washington University School of Medicine, St. Louis, MO, 3. Siteman Cancer Center, Washington University School of Medicine, St. Louis, MO, 4.Department of Genetics, Washington University School of Medicine, St. Louis, MO"
+    },
+    {
+      "name": "Christopher A. Miller^[corresponding author]",
+      "affiliation": "1. Division of Oncology, Department of Internal Medicine, Washington University School of Medicine, St. Louis, MO, 2. Siteman Cancer Center, Washington University School of Medicine, St. Louis, MO"
+    }
+  ],
+   
+  "licence": "MIT"
+}

--- a/build-common/bin/gitrev.pl
+++ b/build-common/bin/gitrev.pl
@@ -24,7 +24,7 @@ sub is_dirty {
 }
 
 sub is_tagged {
-    my $status = git("describe --always --dirty --long");
+    my $status = git("describe --always --dirty --long --tags");
     return 0 if $status =~ /-dirty/;
     if ($status =~ /^.*-([0-9]+)-g[^-]+$/) {
         return $1 == 0;
@@ -34,13 +34,13 @@ sub is_tagged {
 
 sub tagged_version {
     my $rev;
-    eval { $rev = git("describe --long --match $vtag"); };
+    eval { $rev = git("describe --long --tags --match $vtag"); };
     return unless !$@ and $rev ne "";
     return $rev;
 }
 
 sub untagged_version {
-    my $rev = git("describe --always");
+    my $rev = git("describe --always --tags");
     return $rev;
 }
 

--- a/src/exe/bam-readcount/bamreadcount.cpp
+++ b/src/exe/bam-readcount/bamreadcount.cpp
@@ -431,7 +431,7 @@ int main(int argc, char *argv[])
     fetch_data_t *f = (fetch_data_t*)calloc(1, sizeof(pileup_data_t));
     d.tid = -1, d.min_bq = 0, d.max_cnt = 10000000;
 
-    po::options_description desc("Usage: bam-readcount [OPTIONS] <bam_file> [region]\nGenerate metrics for bam_file at single nucleotide positions.\nExample: bam-readcount -f ref.fa some.bam\n\nAvailable options");
+    po::options_description desc("Usage: bam-readcount [OPTIONS] <bam_file>|<cram_file> [region]\nGenerate metrics for bam_file at single nucleotide positions.\nExample: bam-readcount -f ref.fa some.bam|some.cram\n\nAvailable options");
     desc.add_options()
         ("help,h", "produce this message")
         ("version,v", "output the version number")
@@ -478,7 +478,7 @@ int main(int argc, char *argv[])
     /*
     if (argc - optind == 0) {
         fprintf(stderr, "\n");
-        fprintf(stderr, "Usage: bam-readcount <bam_file> [region]\n");
+        fprintf(stderr, "Usage: bam-readcount <bam_file>|<cram_file> [region]\n");
         fprintf(stderr, "        -q INT    filtering reads with mapping quality less than INT [%d]\n", d.min_mapq);
         fprintf(stderr, "        -b INT    don't include reads where the base quality is less than INT [%d]\n", d.min_bq);
         fprintf(stderr, "        -d INT    max depth to avoid excessive memory usage [%d]\n", d.max_cnt);


### PR DESCRIPTION
Fix version flag to trigger conda release
Zenodo auto populates author list based on contributors on github. Manually added `.zenodo.json`  to the root with correct author list.